### PR TITLE
adding least response time algorithm

### DIFF
--- a/internal/core/server.go
+++ b/internal/core/server.go
@@ -1,17 +1,17 @@
 package core
 
 import (
-	"time"
 	"sync"
+	"time"
 )
 
-type Backend struct{
-	Address string
-	Weight int 
-	Alive bool
+type Backend struct {
+	Address     string
+	Weight      int
+	Alive       bool
 	ActiveConns int64
-	Latency time.Duration
-	ErrorCount int64
-	Mutex sync.Mutex
-
+	Latency     time.Duration
+	ErrorCount  int64
+	Mutex       sync.Mutex
+	Emalatency  int64
 }

--- a/internal/proxy/L7/http_proxy.go
+++ b/internal/proxy/L7/http_proxy.go
@@ -37,6 +37,7 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	backend.Mutex.Lock()
 	backend.ActiveConns++
-	backend.Latency = time.Since(start)
+	lat := time.Since(start)
+	backend.Latency = (backend.Latency + lat) / 2
 	backend.Mutex.Unlock()
 }

--- a/internal/proxy/L7/http_proxy.go
+++ b/internal/proxy/L7/http_proxy.go
@@ -35,9 +35,16 @@ func (p *HTTPProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	proxy.ServeHTTP(w, r)
 
+	duration := time.Since(start)
+	latency := time.Since(start).Milliseconds()
 	backend.Mutex.Lock()
-	backend.ActiveConns++
-	lat := time.Since(start)
-	backend.Latency = (backend.Latency + lat) / 2
+	backend.ActiveConns--
+	backend.Latency = duration
+
+	if backend.Emalatency == 0 {
+		backend.Emalatency = latency
+	} else {
+		backend.Emalatency = int64(0.5*float64(latency) + 0.5*float64(backend.Emalatency))
+	}
 	backend.Mutex.Unlock()
 }

--- a/internal/routing/adaptive.go
+++ b/internal/routing/adaptive.go
@@ -9,40 +9,44 @@ import (
 	"github.com/lugnitdgp/TDOC_Routrix/internal/core"
 )
 
-type AdaptiveRouter struct{
-	pool *core.ServerPool
-	rr *RoundRobinRouter
-	lc *LeastConnectionsRouter
-	rn *RandomRouter
+type AdaptiveRouter struct {
+	pool        *core.ServerPool
+	rr          *RoundRobinRouter
+	lc          *LeastConnectionsRouter
+	rn          *RandomRouter
+	lrt         *LeastResponseTimeRouter
 	currentAlgo string
-	reason string
-	lastPicked string
+	reason      string
+	lastPicked  string
 }
-//decision
-type Decision struct{
-	Time time.Time `json:"time"`
-	Algo string `json:"algo"`
-	Reason string `json:"reason"`
-	Backend string `json:"backend"`
+
+// decision
+type Decision struct {
+	Time    time.Time `json:"time"`
+	Algo    string    `json:"algo"`
+	Reason  string    `json:"reason"`
+	Backend string    `json:"backend"`
 }
-var(
+
+var (
 	DecisionLog []Decision
-	DecisionMu sync.Mutex
+	DecisionMu  sync.Mutex
 )
 
-func NewAdaptiveRouter(pool *core.ServerPool) *AdaptiveRouter{
+func NewAdaptiveRouter(pool *core.ServerPool) *AdaptiveRouter {
 	return &AdaptiveRouter{
-		pool: pool,
-		rr: NewRoundRobinRouter(),
-		lc: NewLeastConnectionsRouter(),
-		rn: NewRandomRouter(),
+		pool:        pool,
+		rr:          NewRoundRobinRouter(),
+		lc:          NewLeastConnectionsRouter(),
+		rn:          NewRandomRouter(),
+		lrt:         NewLeastResponseTimeRouter(),
 		currentAlgo: "roundrobin",
-		reason: "normal_conditions",
+		reason:      "normal_conditions",
 	}
 }
-func (ar *AdaptiveRouter) Pick() *core.Backend{
+func (ar *AdaptiveRouter) Pick() *core.Backend {
 	backends := ar.pool.GetServers()
-	if len(backends)==0{
+	if len(backends) == 0 {
 		log.Println("[adaptive] no backends in pool")
 		return nil
 	}
@@ -50,75 +54,77 @@ func (ar *AdaptiveRouter) Pick() *core.Backend{
 	var totalLatency int64
 	var totalErrors int64
 	var maxConns int64
-	aliveCount :=0
+	aliveCount := 0
 
-	for _, b := range backends{
+	for _, b := range backends {
 		b.Mutex.Lock()
-		if b.Alive{
+		if b.Alive {
 			aliveCount++
-			totalConns+=b.ActiveConns
+			totalConns += b.ActiveConns
 			totalLatency += int64(b.Latency)
 			totalErrors += b.ErrorCount
 
-			if b.ActiveConns > maxConns{
-				maxConns=b.ActiveConns
+			if b.ActiveConns > maxConns {
+				maxConns = b.ActiveConns
 			}
 		}
 		b.Mutex.Unlock()
 
 	}
 
-	if aliveCount == 0{
+	if aliveCount == 0 {
 		log.Println("[adaptive] no alive backends")
 		return nil
 	}
 
-	avgConns := totalConns/int64(aliveCount)
-	avgLatency := totalLatency/int64(aliveCount)
-	avgLatencyMs := avgLatency/int64(time.Millisecond)
-	errorRate :=float64(totalErrors)/float64(totalConns+1)
+	avgConns := totalConns / int64(aliveCount)
+	avgLatency := totalLatency / int64(aliveCount)
+	avgLatencyMs := avgLatency / int64(time.Millisecond)
+	errorRate := float64(totalErrors) / float64(totalConns+1)
 
+	log.Printf("Adaptive algo=%s reason=%s picked=%s avgavgConns=%d maxConns=%d avgLatencyMs=%d errorRate=%.2f",
+		ar.currentAlgo, ar.reason, ar.lastPicked, avgConns, maxConns, avgLatencyMs, errorRate)
 
+	var selected *core.Backend
 
-log.Printf("Adaptive algo=%s reason=%s picked=%s avgavgConns=%d maxConns=%d avgLatencyMs=%d errorRate=%.2f",
- ar.currentAlgo, ar.reason, ar.lastPicked, avgConns,maxConns, avgLatencyMs,errorRate,)
-
- var selected *core.Backend
-
- //decision log
-  if errorRate>0.3{
-	ar.currentAlgo="random"
-	ar.reason=fmt.Sprintf("high_error_rate(%.2f)",errorRate)
-	selected=ar.rn.GetNextAvaliableServer(backends)
-  }else if maxConns>3{
-	ar.currentAlgo="leastconnections"
-	ar.reason="high_concurrency"
-	selected=ar.lc.GetNextAvaliableServer(backends)
-  }else{
-	ar.currentAlgo="roundrobin"
-	ar.reason="normal_conditions"
-	selected=ar.rr.GetNextAvaliableServer(backends)
-  }
-if selected != nil{
-	ar.lastPicked=selected.Address
-	DecisionMu.Lock()
-	DecisionLog= append(DecisionLog, Decision{
-		Time: time.Now(),
-		Algo: ar.currentAlgo,
-		Reason: ar.reason,
-		Backend: selected.Address,
-	})
-	DecisionMu.Unlock()
+	//decision log
+	if errorRate > 0.3 {
+		ar.currentAlgo = "random"
+		ar.reason = fmt.Sprintf("high_error_rate(%.2f)", errorRate)
+		selected = ar.rn.GetNextAvaliableServer(backends)
+	} else if maxConns > 3 {
+		ar.currentAlgo = "leastconnections"
+		ar.reason = "high_concurrency"
+		selected = ar.lc.GetNextAvaliableServer(backends)
+	} else if avgLatencyMs > 50 {
+		ar.currentAlgo = "leastresponsetime"
+		ar.reason = fmt.Sprintf("high_latency(%dms)", avgLatencyMs)
+		selected = ar.lrt.GetNextAvaliableServer(backends)
+	} else {
+		ar.currentAlgo = "roundrobin"
+		ar.reason = "normal_conditions"
+		selected = ar.rr.GetNextAvaliableServer(backends)
+	}
+	if selected != nil {
+		ar.lastPicked = selected.Address
+		DecisionMu.Lock()
+		DecisionLog = append(DecisionLog, Decision{
+			Time:    time.Now(),
+			Algo:    ar.currentAlgo,
+			Reason:  ar.reason,
+			Backend: selected.Address,
+		})
+		DecisionMu.Unlock()
+	}
+	return selected
 }
-return selected
-}
 
-func (ar *AdaptiveRouter) GetNextAvaliableServer(_ []*core.Backend) *core.Backend{
+func (ar *AdaptiveRouter) GetNextAvaliableServer(_ []*core.Backend) *core.Backend {
 	return ar.Pick()
 }
-func(ar *AdaptiveRouter)Name()string{
-	return"adaptive"
+func (ar *AdaptiveRouter) Name() string {
+	return "adaptive"
 }
-func(ar *AdaptiveRouter)CurrentAlgo() string {return ar.currentAlgo}
-func(ar *AdaptiveRouter) Reason() string{return ar.reason}
-func(ar *AdaptiveRouter) LastPicked() string{ return ar.lastPicked}
+func (ar *AdaptiveRouter) CurrentAlgo() string { return ar.currentAlgo }
+func (ar *AdaptiveRouter) Reason() string      { return ar.reason }
+func (ar *AdaptiveRouter) LastPicked() string  { return ar.lastPicked }

--- a/internal/routing/leastresponsetime.go
+++ b/internal/routing/leastresponsetime.go
@@ -1,0 +1,37 @@
+package routing
+
+import (
+	"math"
+
+	"github.com/lugnitdgp/TDOC_Routrix/internal/core"
+)
+
+type LeastResponseTimeRouter struct {
+}
+
+func NewLeastResponseTimeRouter() *LeastResponseTimeRouter {
+	return &LeastResponseTimeRouter{}
+}
+func (lrt *LeastResponseTimeRouter) GetNextAvaliableServer(
+	backends []*core.Backend,
+) *core.Backend {
+	var chosenOne *core.Backend
+	var minLatency int64 = math.MaxInt64
+	for _, backend := range backends {
+		backend.Mutex.Lock()
+		alive := backend.Alive
+		avgLat := backend.Emalatency
+		backend.Mutex.Unlock()
+		if !alive {
+			continue
+		}
+		if avgLat < minLatency {
+			minLatency = avgLat
+			chosenOne = backend
+		}
+	}
+	return chosenOne
+}
+func (lrt *LeastResponseTimeRouter) Name() string {
+	return "Least Response Time"
+}


### PR DESCRIPTION
**Changes:**

1. A new algorithm [leastresponsetime.go](http://leastresponsetime.go/) is added in internal/routing/ . The backend with the lowest exponential moving average(EMA) latency is selected. Here, EMA is implemented because it prioritizes most recent requests, which is helpful for least response time(LRT) routing.
2. [adaptive.go](http://adaptive.go/) in internal/routing is updated to initialize LRT. When the average latency exceeds 50ms, we automatically switch to least response time algorithm.
3. L7 and H4 proxies are updated to add EMA latency tracking.

**Testing:**

Tested locally with a simulated delay (0ms , 300ms).
20 requests were sent. Initially, the system used the safest method, round robin. After a few requests, when the latency crossed the threshold 50ms, it switched to least response time.

https://drive.google.com/file/d/1baX5YgwHVzNVvcNYT6m682A73IWxr8Nw/view?usp=drive_link